### PR TITLE
Improve UI with dark mode persistence

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1,0 +1,11 @@
+// Apply saved theme on load
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('darkMode') === 'true') {
+    document.body.classList.add('dark-mode');
+  }
+});
+
+function toggleDarkMode() {
+  document.body.classList.toggle('dark-mode');
+  localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,29 @@
+/* Global Styles */
+body {
+    font-family: 'Arial', sans-serif;
+}
+
+/* Persistent Dark Mode */
+.dark-mode {
+    background: #1e1e1e;
+    color: #ffffff;
+}
+
+.dark-mode-toggle {
+    cursor: pointer;
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: white;
+    color: black;
+    padding: 10px 15px;
+    border-radius: 50%;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+    transition: background 0.3s ease-in-out, transform 0.3s ease-in-out;
+    z-index: 1000;
+}
+
+.dark-mode-toggle:hover {
+    background: #ccc;
+    transform: scale(1.1);
+}

--- a/views/index.html
+++ b/views/index.html
@@ -8,6 +8,7 @@
     <!-- Materialize CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
 
     <style>
         /* Global Styles */
@@ -189,10 +190,6 @@
 
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script>
-        function toggleDarkMode() {
-            document.body.classList.toggle('dark-mode');
-        }
-    </script>
+    <script src="/static/scripts.js"></script>
 </body>
 </html>

--- a/views/record-video.html
+++ b/views/record-video.html
@@ -8,6 +8,7 @@
     <!-- Materialize CSS -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+<link rel="stylesheet" href="/static/style.css">
 
     <style>
         /* Global Styles */
@@ -132,6 +133,9 @@
     </div>
 
 
+    <div class="dark-mode-toggle" onclick="toggleDarkMode()">
+        <i class="material-icons">brightness_4</i>
+    </div>
     <!-- Materialize JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script>
@@ -234,5 +238,6 @@
             }
         }
     </script>
+<script src="/static/scripts.js"></script>
 </body>
 </html>

--- a/views/upload-images.html
+++ b/views/upload-images.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
+<link rel="stylesheet" href="/static/style.css">
     <style>
         /* Global Styles */
         body {
@@ -184,6 +185,9 @@
         </div>
     </div>
 
+    <div class="dark-mode-toggle" onclick="toggleDarkMode()">
+        <i class="material-icons">brightness_4</i>
+    </div>
 
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
@@ -263,5 +267,6 @@
         }
     });
 </script>
+<script src="/static/scripts.js"></script>
 </body>
 </html>

--- a/views/view-images.html
+++ b/views/view-images.html
@@ -8,6 +8,7 @@
   <!-- Materialize CSS -->
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+<link rel="stylesheet" href="/static/style.css">
 
   <style>
     /* General Styles */
@@ -299,10 +300,8 @@
       });
     });
 
-    function toggleDarkMode() {
-      document.body.classList.toggle('dark-mode');
-    }
   </script>
 
+<script src="/static/scripts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add shared style.css and scripts.js in static
- enable persistent dark mode toggle using localStorage
- include toggle on all pages
- reference shared scripts and styles from HTML views

## Testing
- `python -m py_compile main.py`
- `python -m py_compile src/*.py`
