### PR TITLE
Improve UI with help modals and polished theme

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1,0 +1,23 @@
+// Apply saved theme on load
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('darkMode') === 'true') {
+    document.body.classList.add('dark-mode');
+  }
+  const tooltipped = document.querySelectorAll('.tooltipped');
+  M.Tooltip.init(tooltipped);
+  const modals = document.querySelectorAll('.modal');
+  M.Modal.init(modals);
+});
+
+function toggleDarkMode() {
+  document.body.classList.toggle('dark-mode');
+  localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+}
+
+function openHelp() {
+  const modal = document.getElementById('helpModal');
+  if (modal) {
+    const instance = M.Modal.getInstance(modal) || M.Modal.init(modal);
+    instance.open();
+  }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,48 @@
+/* Global Styles */
+body {
+    font-family: 'Poppins', 'Arial', sans-serif;
+}
+
+/* Persistent Dark Mode */
+.dark-mode {
+    background: #1e1e1e;
+    color: #ffffff;
+}
+
+.dark-mode-toggle {
+    cursor: pointer;
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: white;
+    color: black;
+    padding: 10px 15px;
+    border-radius: 50%;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+    transition: background 0.3s ease-in-out, transform 0.3s ease-in-out;
+    z-index: 1000;
+}
+
+.dark-mode-toggle:hover {
+    background: #ccc;
+    transform: scale(1.1);
+}
+
+.help-btn {
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
+    background: #2196F3;
+    color: white;
+    padding: 10px 15px;
+    border-radius: 50%;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    transition: background 0.3s ease-in-out, transform 0.3s ease-in-out;
+    z-index: 1000;
+}
+
+.help-btn:hover {
+    background: #1976D2;
+    transform: scale(1.1);
+}

--- a/views/index.html
+++ b/views/index.html
@@ -8,11 +8,13 @@
     <!-- Materialize CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
 
     <style>
         /* Global Styles */
         body {
-            font-family: 'Arial', sans-serif;
+            font-family: 'Poppins', 'Arial', sans-serif;
             background: linear-gradient(to right, #2196F3, #64B5F6); /* Gradient background */
             color: white;
             transition: background 0.5s ease-in-out, color 0.5s ease-in-out;
@@ -182,17 +184,29 @@
         </div>
     </div>
 
+    <!-- Help Modal -->
+    <div id="helpModal" class="modal">
+        <div class="modal-content">
+            <h5>Welcome to PlantGuard</h5>
+            <p>Use <strong>Live View</strong> to capture frames from your camera or <strong>Upload Image</strong> to analyze existing photos. View all results in the Image Library.</p>
+        </div>
+        <div class="modal-footer">
+            <a href="#!" class="modal-close btn blue">Close</a>
+        </div>
+    </div>
+
     <!-- Dark Mode Toggle -->
-    <div class="dark-mode-toggle" onclick="toggleDarkMode()">
+    <div class="dark-mode-toggle tooltipped" data-tooltip="Toggle dark mode" onclick="toggleDarkMode()">
         <i class="material-icons">brightness_4</i>
+    </div>
+
+    <!-- Help Button -->
+    <div class="help-btn tooltipped" data-position="right" data-tooltip="How to use" onclick="openHelp()">
+        <i class="material-icons">help_outline</i>
     </div>
 
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script>
-        function toggleDarkMode() {
-            document.body.classList.toggle('dark-mode');
-        }
-    </script>
+    <script src="/static/scripts.js"></script>
 </body>
 </html>

--- a/views/record-video.html
+++ b/views/record-video.html
@@ -8,11 +8,13 @@
     <!-- Materialize CSS -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/style.css">
 
     <style>
         /* Global Styles */
         body {
-            font-family: 'Arial', sans-serif;
+            font-family: 'Poppins', 'Arial', sans-serif;
             background: linear-gradient(to right, #2196F3, #64B5F6);
             color: white;
             transition: background 0.5s ease-in-out, color 0.5s ease-in-out;
@@ -132,6 +134,24 @@
     </div>
 
 
+    <!-- Help Modal -->
+    <div id="helpModal" class="modal">
+        <div class="modal-content">
+            <h5>Recording Help</h5>
+            <p>Connect your webcam, start recording and frames will be analyzed automatically.</p>
+        </div>
+        <div class="modal-footer">
+            <a href="#!" class="modal-close btn blue">Close</a>
+        </div>
+    </div>
+
+    <div class="dark-mode-toggle tooltipped" data-tooltip="Toggle dark mode" onclick="toggleDarkMode()">
+        <i class="material-icons">brightness_4</i>
+    </div>
+
+    <div class="help-btn tooltipped" data-position="right" data-tooltip="How to use" onclick="openHelp()">
+        <i class="material-icons">help_outline</i>
+    </div>
     <!-- Materialize JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script>
@@ -234,5 +254,6 @@
             }
         }
     </script>
+<script src="/static/scripts.js"></script>
 </body>
 </html>

--- a/views/upload-images.html
+++ b/views/upload-images.html
@@ -8,11 +8,13 @@
     <!-- Materialize CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
 
+<link rel="stylesheet" href="/static/style.css">
     <style>
         /* Global Styles */
         body {
-            font-family: 'Arial', sans-serif;
+            font-family: 'Poppins', 'Arial', sans-serif;
             background: linear-gradient(to right, #2196F3, #64B5F6);
             color: white;
             transition: background 0.5s ease-in-out, color 0.5s ease-in-out;
@@ -184,6 +186,24 @@
         </div>
     </div>
 
+    <!-- Help Modal -->
+    <div id="helpModal" class="modal">
+        <div class="modal-content">
+            <h5>Upload Help</h5>
+            <p>Select one or more images and click Submit to analyze them.</p>
+        </div>
+        <div class="modal-footer">
+            <a href="#!" class="modal-close btn blue">Close</a>
+        </div>
+    </div>
+
+    <div class="dark-mode-toggle tooltipped" data-tooltip="Toggle dark mode" onclick="toggleDarkMode()">
+        <i class="material-icons">brightness_4</i>
+    </div>
+
+    <div class="help-btn tooltipped" data-position="right" data-tooltip="How to use" onclick="openHelp()">
+        <i class="material-icons">help_outline</i>
+    </div>
 
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
@@ -263,5 +283,6 @@
         }
     });
 </script>
+<script src="/static/scripts.js"></script>
 </body>
 </html>

--- a/views/view-images.html
+++ b/views/view-images.html
@@ -8,11 +8,13 @@
   <!-- Materialize CSS -->
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/style.css">
 
   <style>
     /* General Styles */
     body {
-      font-family: 'Arial', sans-serif;
+      font-family: 'Poppins', 'Arial', sans-serif;
       background: linear-gradient(to right, #1565C0, #64B5F6);
       color: white;
       transition: background 0.5s ease-in-out, color 0.5s ease-in-out;
@@ -189,9 +191,25 @@
     </div>
   </div>
 
+  <!-- Help Modal -->
+  <div id="helpModal" class="modal">
+    <div class="modal-content">
+      <h5>Gallery Help</h5>
+      <p>Browse your uploaded images here. Click on any image to view it full screen or get more info.</p>
+    </div>
+    <div class="modal-footer">
+      <a href="#!" class="modal-close btn blue">Close</a>
+    </div>
+  </div>
+
   <!-- Dark Mode Toggle -->
-  <div class="dark-mode-toggle" onclick="toggleDarkMode()">
+  <div class="dark-mode-toggle tooltipped" data-tooltip="Toggle dark mode" onclick="toggleDarkMode()">
     <i class="material-icons">brightness_4</i>
+  </div>
+
+  <!-- Help Button -->
+  <div class="help-btn tooltipped" data-position="right" data-tooltip="How to use" onclick="openHelp()">
+    <i class="material-icons">help_outline</i>
   </div>
 
   <!-- Materialize JS -->
@@ -299,10 +317,8 @@
       });
     });
 
-    function toggleDarkMode() {
-      document.body.classList.toggle('dark-mode');
-    }
   </script>
 
+<script src="/static/scripts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use Google Poppins font across pages
- implement help modals and floating help buttons
- add tooltips for dark mode toggle
- init Materialize components in shared script

## Testing
- `python -m py_compile main.py`
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6848034a800c8320969a793188608e74