### PR TITLE
Add upload timestamps and history endpoint; refactor UI into `AppUI` with theme/history UX enhancements

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import traceback
+from datetime import datetime, timezone
 from typing import List
 from pydantic import BaseModel
 from pathlib import Path
@@ -185,6 +186,7 @@ async def upload_files(files: List[UploadFile] = File(...)):
                 "plant": plant_prediction,
                 "disease": disease_prediction,
                 "heatmap": os.path.basename(heatmap_path) if heatmap_path else None,
+                "uploadDate": datetime.now(timezone.utc).isoformat(),
             }
             predictions.append(pred)
             PREDICTIONS[unique_name] = pred
@@ -206,9 +208,21 @@ async def get_images():
             "filename": file,
             "plant": pred.get("plant", ""),
             "disease": pred.get("disease", ""),
-            "heatmap": pred.get("heatmap")
+            "heatmap": pred.get("heatmap"),
+            "uploadDate": pred.get("uploadDate"),
         })
     return results
+
+
+@app.get("/history")
+async def get_history(limit: int = 10):
+    entries = sorted(
+        PREDICTIONS.values(),
+        key=lambda item: item.get("uploadDate", ""),
+        reverse=True
+    )
+    safe_limit = max(1, min(limit, 100))
+    return entries[:safe_limit]
 
 
 @app.post("/explain-diagnosis")

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1,14 +1,115 @@
-// Apply saved theme on load
-document.addEventListener('DOMContentLoaded', () => {
-  if (window.AOS) {
-    AOS.init();
-  }
-  if (localStorage.getItem('darkMode') === 'true') {
-    document.body.classList.add('dark-mode');
-  }
-});
+(function () {
+  const THEME_KEY = 'theme';
 
-function toggleDarkMode() {
-  document.body.classList.toggle('dark-mode');
-  localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
-}
+  function applyTheme(theme) {
+    const body = document.body;
+    const icon = document.getElementById('themeIcon');
+    const isDark = theme === 'dark';
+
+    if (isDark) {
+      body.setAttribute('data-theme', 'dark');
+      body.classList.add('dark-mode');
+    } else {
+      body.removeAttribute('data-theme');
+      body.classList.remove('dark-mode');
+    }
+
+    if (icon) {
+      icon.className = isDark ? 'fas fa-sun' : 'fas fa-moon';
+    }
+  }
+
+  function getSavedTheme() {
+    const saved = localStorage.getItem(THEME_KEY);
+    if (saved === 'dark' || saved === 'light') return saved;
+
+    const legacy = localStorage.getItem('darkMode');
+    if (legacy === 'true') return 'dark';
+    return 'light';
+  }
+
+  function toggleTheme() {
+    const nextTheme = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    applyTheme(nextTheme);
+    localStorage.setItem(THEME_KEY, nextTheme);
+    localStorage.setItem('darkMode', String(nextTheme === 'dark'));
+  }
+
+  function initTheme() {
+    applyTheme(getSavedTheme());
+  }
+
+  function initAOS() {
+    if (!window.AOS) return;
+    AOS.init({
+      duration: 700,
+      easing: 'ease-out-cubic',
+      once: true,
+      offset: 80
+    });
+  }
+
+  function initNavbarScroll() {
+    const navbar = document.querySelector('.navbar-custom');
+    if (!navbar) return;
+
+    const update = () => {
+      navbar.classList.toggle('nav-scrolled', window.scrollY > 30);
+    };
+
+    update();
+    window.addEventListener('scroll', update);
+  }
+
+  function initButtonLoading(selector) {
+    document.querySelectorAll(selector).forEach((btn) => {
+      btn.addEventListener('click', function () {
+        const originalContent = this.innerHTML;
+        this.style.pointerEvents = 'none';
+        this.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Loading...';
+        setTimeout(() => {
+          this.innerHTML = originalContent;
+          this.style.pointerEvents = 'auto';
+        }, 900);
+      });
+    });
+  }
+
+  function saveHistoryEntries(predictions) {
+    if (!Array.isArray(predictions)) return;
+
+    const existing = JSON.parse(localStorage.getItem('analysisHistory') || '[]');
+    const stamped = predictions.map((item) => ({
+      ...item,
+      timestamp: item.timestamp || new Date().toISOString()
+    }));
+    const merged = [...stamped, ...existing].slice(0, 50);
+    localStorage.setItem('analysisHistory', JSON.stringify(merged));
+  }
+
+  function initPage(options = {}) {
+    initTheme();
+    initAOS();
+    initNavbarScroll();
+
+    if (options.enableButtonLoading) {
+      initButtonLoading(options.enableButtonLoading);
+    }
+
+    if (window.M) {
+      M.AutoInit();
+    }
+  }
+
+  window.toggleDarkMode = toggleTheme;
+  window.AppUI = {
+    initTheme,
+    initAOS,
+    initNavbarScroll,
+    initButtonLoading,
+    initPage,
+    saveHistoryEntries
+  };
+
+  document.addEventListener('DOMContentLoaded', initTheme);
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -68,3 +68,86 @@ body {
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
     padding: 20px;
 }
+
+/* Shared elevation system */
+:root {
+    --motion-fast: 180ms;
+    --motion-base: 280ms;
+    --motion-slow: 420ms;
+    --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.navbar-custom.nav-scrolled {
+    box-shadow: 0 10px 25px -12px rgba(0, 0, 0, 0.35);
+    transform: translateY(0);
+}
+
+.interactive-card {
+    transition: transform var(--motion-base) var(--ease-standard), box-shadow var(--motion-base) var(--ease-standard);
+}
+
+.interactive-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 18px 36px -20px rgba(0, 0, 0, 0.45);
+}
+
+.sticky-cta {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 900;
+    border-radius: 999px;
+    padding: 0.8rem 1.2rem;
+    color: #fff;
+    font-weight: 600;
+    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    box-shadow: 0 10px 20px -10px rgba(37, 99, 235, 0.55);
+}
+
+.onboarding-banner {
+    margin: 1.2rem auto 0;
+    max-width: 1100px;
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    border: 1px solid rgba(255,255,255,0.2);
+    background: rgba(59,130,246,0.12);
+    color: #e2e8f0;
+    display: none;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.onboarding-banner.show {
+    display: flex;
+}
+
+.history-panel {
+    margin: 1.4rem 0;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(255,255,255,0.75);
+    border: 1px solid rgba(148,163,184,0.35);
+}
+
+.history-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.8rem;
+}
+
+.history-item {
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    padding: 0.75rem;
+    background: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}

--- a/views/index.html
+++ b/views/index.html
@@ -681,6 +681,39 @@
         </div>
     </section>
 
+
+    <!-- How It Works -->
+    <section class="features-section" style="padding-top:0;">
+        <div class="features-container">
+            <div class="section-header" data-aos="fade-up">
+                <h2 class="section-title">How It Works</h2>
+                <p class="section-subtitle">A streamlined workflow from capture to treatment guidance.</p>
+            </div>
+            <div class="features-grid">
+                <div class="feature-card interactive-card" data-aos="fade-up" data-aos-delay="80">
+                    <div class="feature-icon"><i class="fas fa-camera"></i></div>
+                    <h3 class="feature-title">Capture</h3>
+                    <p class="feature-description">Take clear photos of affected leaves or upload multiple angles for stronger diagnosis confidence.</p>
+                </div>
+                <div class="feature-card interactive-card" data-aos="fade-up" data-aos-delay="160">
+                    <div class="feature-icon"><i class="fas fa-microchip"></i></div>
+                    <h3 class="feature-title">Analyze</h3>
+                    <p class="feature-description">PlantGuard runs plant and disease classification with heatmap explanations in seconds.</p>
+                </div>
+                <div class="feature-card interactive-card" data-aos="fade-up" data-aos-delay="240">
+                    <div class="feature-icon"><i class="fas fa-stethoscope"></i></div>
+                    <h3 class="feature-title">Act</h3>
+                    <p class="feature-description">Review recommendations and take fast preventive action to protect crop yield.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <div class="onboarding-banner" id="onboardingBanner">
+        <span><strong>New here?</strong> Start with Upload Images, then check your Analysis Dashboard.</span>
+        <a href="/upload-images" class="btn-small waves-effect waves-light" style="background:#3b82f6;">Start onboarding</a>
+    </div>
+
     <!-- CTA Section -->
     <section class="cta-section" data-aos="fade-up">
         <div class="cta-container">
@@ -707,93 +740,29 @@
         <i class="fas fa-moon" id="themeIcon"></i>
     </div>
 
+    <a class="sticky-cta" href="/upload-images">
+        <i class="fas fa-cloud-upload-alt"></i> Analyze a Plant
+    </a>
+
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="/static/scripts.js"></script>
     
     <script>
-        // Initialize AOS animations
-        document.addEventListener('DOMContentLoaded', function() {
-            AOS.init({
-                duration: 800,
-                easing: 'ease-in-out',
-                once: true,
-                offset: 100
-            });
-        });
+        document.addEventListener('DOMContentLoaded', function () {
+            AppUI.initPage({ enableButtonLoading: '.hero-btn, .cta-btn' });
 
-        // Enhanced theme toggle functionality
-        function toggleDarkMode() {
-            const body = document.body;
-            const themeIcon = document.getElementById('themeIcon');
-            
-            if (body.getAttribute('data-theme') === 'dark') {
-                body.removeAttribute('data-theme');
-                themeIcon.className = 'fas fa-moon';
-                localStorage.setItem('theme', 'light');
-            } else {
-                body.setAttribute('data-theme', 'dark');
-                themeIcon.className = 'fas fa-sun';
-                localStorage.setItem('theme', 'dark');
-            }
-        }
-
-        // Initialize theme from localStorage
-        if (localStorage.getItem('theme') === 'dark') {
-            document.body.setAttribute('data-theme', 'dark');
-            document.getElementById('themeIcon').className = 'fas fa-sun';
-        }
-
-        // Enhanced navbar scroll effect
-        window.addEventListener('scroll', function() {
-            const navbar = document.querySelector('.navbar-custom');
-            if (window.scrollY > 50) {
-                navbar.style.background = window.getComputedStyle(document.documentElement)
-                    .getPropertyValue('--surface-primary');
-                navbar.style.backdropFilter = 'blur(20px)';
-                navbar.style.boxShadow = 'var(--shadow-lg)';
-            } else {
-                navbar.style.background = 'rgba(255, 255, 255, 0.95)';
-                navbar.style.backdropFilter = 'blur(20px)';
-                navbar.style.boxShadow = 'var(--shadow-sm)';
-            }
-        });
-
-        // Smooth scrolling for anchor links
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', function (e) {
-                e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
-                if (target) {
-                    target.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'start'
-                    });
-                }
-            });
-        });
-
-        // Add loading states to buttons
-        document.querySelectorAll('.hero-btn, .cta-btn').forEach(btn => {
-            btn.addEventListener('click', function(e) {
-                // Don't prevent default - we want the navigation to work
-                const originalContent = this.innerHTML;
-                this.style.pointerEvents = 'none';
-                this.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Loading...';
-                
-                // Reset after a short delay to allow navigation
+            const banner = document.getElementById('onboardingBanner');
+            const hasSeenBanner = localStorage.getItem('seenOnboardingBanner') === 'true';
+            if (banner && !hasSeenBanner) {
+                banner.classList.add('show');
                 setTimeout(() => {
-                    this.innerHTML = originalContent;
-                    this.style.pointerEvents = 'auto';
-                }, 1000);
-            });
+                    localStorage.setItem('seenOnboardingBanner', 'true');
+                }, 6000);
+            }
         });
-
-        // Initialize Materialize components
-        if (typeof M !== 'undefined') {
-            M.AutoInit();
-        }
     </script>
+
 </body>
 </html>

--- a/views/upload-images.html
+++ b/views/upload-images.html
@@ -1311,15 +1311,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script>
-        // Initialize AOS animations
-        document.addEventListener('DOMContentLoaded', function() {
-            AOS.init({
-                duration: 800,
-                easing: 'ease-in-out',
-                once: true,
-                offset: 100
-            });
-        });
 
         // State management
         let selectedFiles = [];
@@ -1329,28 +1320,6 @@
         let fileInput, uploadZone, previewSection, previewContainer, previewCount;
         let submitBtn, clearBtn, responseMessage, responseText, progressContainer;
         let progressText, progressPercent, progressFill;
-
-        // Theme Management
-        function toggleDarkMode() {
-            const body = document.body;
-            const themeIcon = document.getElementById('themeIcon');
-            
-            if (body.getAttribute('data-theme') === 'dark') {
-                body.removeAttribute('data-theme');
-                themeIcon.className = 'fas fa-moon';
-                localStorage.setItem('theme', 'light');
-            } else {
-                body.setAttribute('data-theme', 'dark');
-                themeIcon.className = 'fas fa-sun';
-                localStorage.setItem('theme', 'dark');
-            }
-        }
-
-        // Initialize theme
-        if (localStorage.getItem('theme') === 'dark') {
-            document.body.setAttribute('data-theme', 'dark');
-            document.getElementById('themeIcon').className = 'fas fa-sun';
-        }
 
         // File validation
         function isValidImageFile(file) {
@@ -1552,6 +1521,9 @@
                 updateProgress(100, 'Analysis complete!', 4);
                 
                 if (response.ok) {
+                    if (window.AppUI && Array.isArray(result.predictions)) {
+                        AppUI.saveHistoryEntries(result.predictions);
+                    }
                     showMessage(result.message || 'Images analyzed successfully! Redirecting to results...', 'success');
                     
                     // Redirect after success
@@ -1575,6 +1547,9 @@
 
         // Initialize
         document.addEventListener('DOMContentLoaded', function() {
+            if (window.AppUI) {
+                AppUI.initPage();
+            }
             // Initialize DOM elements
             fileInput = document.getElementById('fileInput');
             uploadZone = document.getElementById('uploadZone');

--- a/views/view-images.html
+++ b/views/view-images.html
@@ -1092,6 +1092,12 @@
       </div>
     </div>
 
+    <div class="history-panel">
+      <h5><i class="fas fa-history"></i> Recent Analyses</h5>
+      <div id="historyList" class="history-list"></div>
+      <div id="comparisonSummary" style="margin-top:0.8rem; color: var(--text-secondary); font-weight: 600;"></div>
+    </div>
+
     <!-- Image Gallery -->
     <div id="loadingState" class="loading" style="display: none;">
       <div class="loading-spinner"></div>
@@ -1195,28 +1201,6 @@
     let imagesData = [];
     let currentView = 'grid';
     let currentFilter = '';
-
-    // Theme Management
-    function toggleDarkMode() {
-      const body = document.body;
-      const themeIcon = document.getElementById('themeIcon');
-      
-      if (body.getAttribute('data-theme') === 'dark') {
-        body.removeAttribute('data-theme');
-        themeIcon.className = 'fas fa-moon';
-        localStorage.setItem('theme', 'light');
-      } else {
-        body.setAttribute('data-theme', 'dark');
-        themeIcon.className = 'fas fa-sun';
-        localStorage.setItem('theme', 'dark');
-      }
-    }
-
-    // Initialize theme
-    if (localStorage.getItem('theme') === 'dark') {
-      document.body.setAttribute('data-theme', 'dark');
-      document.getElementById('themeIcon').className = 'fas fa-sun';
-    }
 
     // View Toggle Management
     function setView(viewType) {
@@ -1360,6 +1344,48 @@
     function showEmptyState() {
       document.getElementById('emptyState').style.display = 'block';
       document.getElementById('imageGallery').style.display = 'none';
+    }
+
+    function renderHistory(historyItems) {
+      const historyList = document.getElementById('historyList');
+      const comparisonSummary = document.getElementById('comparisonSummary');
+      if (!historyList || !comparisonSummary) return;
+
+      if (!historyItems.length) {
+        historyList.innerHTML = '<div class="history-item">No recent analyses yet.</div>';
+        comparisonSummary.textContent = '';
+        return;
+      }
+
+      historyList.innerHTML = historyItems.slice(0, 6).map(item => `
+        <div class="history-item interactive-card">
+          <div><strong>${item.plant || 'Unknown plant'}</strong></div>
+          <div>${item.disease || 'Unknown disease'}</div>
+          <div style="font-size:0.8rem; color:#64748b;">${new Date(item.uploadDate || item.timestamp || Date.now()).toLocaleString()}</div>
+        </div>
+      `).join('');
+
+      if (historyItems.length >= 2) {
+        const [latest, previous] = historyItems;
+        comparisonSummary.textContent = `Comparison: ${latest.plant || 'Plant'} changed from “${previous.disease || 'Unknown'}” to “${latest.disease || 'Unknown'}”.`;
+      } else {
+        comparisonSummary.textContent = 'Add one more analysis to unlock comparison insights.';
+      }
+    }
+
+    async function fetchHistory() {
+      try {
+        const res = await fetch('/history?limit=10');
+        if (res.ok) {
+          const serverHistory = await res.json();
+          renderHistory(serverHistory);
+          return;
+        }
+      } catch (error) {
+        console.warn('Using local history fallback', error);
+      }
+      const localHistory = JSON.parse(localStorage.getItem('analysisHistory') || '[]');
+      renderHistory(localHistory);
     }
 
     // Enhanced Card Creation
@@ -1640,6 +1666,9 @@
 
     // Event Listeners
     document.addEventListener('DOMContentLoaded', () => {
+      if (window.AppUI) {
+        AppUI.initPage();
+      }
       // Initialize Materialize components
       M.Modal.init(document.querySelectorAll('.modal'));
       M.Tooltip.init(document.querySelectorAll('[title]'));
@@ -1663,6 +1692,7 @@
       
       // Fetch initial data
       fetchImages();
+      fetchHistory();
     });
 
     // Initialize components


### PR DESCRIPTION
### Motivation
- Record when images are analyzed so the UI can present recent analyses and allow sorting/filtering by time.
- Centralize and modernize front-end initialization and UX behaviors (theme toggle, AOS, navbar, button loading) into a reusable module.
- Surface a server-backed history and a client fallback so recent analyses are accessible even when offline.

### Description
- Backend: import `datetime` and add an `uploadDate` timestamp to each prediction using `datetime.now(timezone.utc).isoformat()` and expose it via the `/images` response and a new `/history` endpoint that returns recent entries sorted by `uploadDate`. 
- Frontend JS: replace scattered DOM-init code with a self-contained `AppUI` module in `static/scripts.js` providing `initPage`, `initTheme`, `initAOS`, `initNavbarScroll`, `initButtonLoading`, and `saveHistoryEntries`, and expose `toggleDarkMode` globally.
- Views and UX: update `views/*.html` to use `AppUI.initPage`, remove duplicate theme/AOS scripts, add a "How It Works" section, onboarding banner, sticky CTA, and a `history-panel` with `renderHistory` and `fetchHistory` which prefers server `/history` and falls back to local `analysisHistory` stored by `AppUI.saveHistoryEntries`.
- Styling: add CSS for `interactive-card`, `sticky-cta`, `onboarding-banner`, `history-panel`, motion variables, and accessibility reduced-motion support in `static/style.css`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd71711b0483209fe473edb6d69eb4)